### PR TITLE
Remove libreddit.himiko.cloud instance

### DIFF
--- a/src/assets/javascripts/helpers/reddit.js
+++ b/src/assets/javascripts/helpers/reddit.js
@@ -21,7 +21,6 @@ let redirects = {
       "https://libreddit.insanity.wtf",
       "https://libreddit.dothq.co",
       "https://libreddit.silkky.cloud",
-      "https://libreddit.himiko.cloud",
       "https://reddit.artemislena.eu",
       "https://reddit.git-bruh.duckdns.org",
     ]


### PR DESCRIPTION
The instance `https://libreddit.himiko.cloud` redirects to some random malicious sites which are usually blocked by ublock.