### PR TITLE
Add web-ext dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Send Files => [Send](https://github.com/timvisee/send)
 - [Node.js](https://nodejs.org/) latest LTS is recommended
 - `npm update`
 - `npm install`
+- `npm i web-ext`
 
 ### Build
 - `npm run build`


### PR DESCRIPTION
Users who want to build LibRedirect as a WebExtension must install [web-ext](https://www.npmjs.com/package/web-ext) or they will face an error.