### PR TITLE
Fixes typo on the Search page

### DIFF
--- a/src/pages/options/search/search.html
+++ b/src/pages/options/search/search.html
@@ -154,7 +154,7 @@
     </div>
 
     <div class="some-block">
-      <h4>Note: To use Search to it's full potential, make LibRedirect as the
+      <h4>Note: To use Search to its full potential, make LibRedirect as the
         Default Search Engine
       </h4>
     </div>


### PR DESCRIPTION
Hello. This fixes a typo on the Search page.

it's full potential -> its full potential