### PR TITLE
Bugfix | correct ﻿domain name wiki.froth.zone

### DIFF
--- a/src/instances/data.json
+++ b/src/instances/data.json
@@ -160,7 +160,7 @@
       "https://wikiless.sethforprivacy.com",
       "https://wiki.604kph.xyz",
       "https://wikiless.lunar.icu",
-      "https://https://wiki.froth.zone",
+      "https://wiki.froth.zone",
       "https://hflqp2ejxygpj6cdwo3ogfieqmxw3b56w7dblt7bor2ltwk6kcfa.b32.i2p"
     ],
     "tor": [


### PR DESCRIPTION
You doubled https