### PR TITLE
Fixes a typo on Wikiless instance URL

### DIFF
--- a/src/instances/data.json
+++ b/src/instances/data.json
@@ -259,7 +259,7 @@
       "https://wikiless.sethforprivacy.com",
       "https://wiki.604kph.xyz",
       "https://wikiless.lunar.icu",
-      "https://https://wiki.froth.zone"
+      "https://wiki.froth.zone"
     ],
     "tor": [
       "http://dj2tbh2nqfxyfmvq33cjmhuw7nb6am7thzd3zsjvizeqf374fixbrxyd.onion",


### PR DESCRIPTION
I was getting an error like:
```
"Hmm. We’re having trouble finding that site.
We can’t connect to the server at https."
```
and then realized that it was only a typo on the URL