### PR TITLE
Add searx.garudalinux.org + google.censors.us

### DIFF
--- a/src/instances/data.json
+++ b/src/instances/data.json
@@ -407,6 +407,7 @@
     "normal": [
       "https://darmarit.org/searx",
       "https://etsi.me",
+      "https://google.censors.us",
       "https://northboot.xyz",
       "https://paulgo.io",
       "https://s.zhaocloud.net",
@@ -420,6 +421,7 @@
       "https://searx.ebnar.xyz",
       "https://searx.esmailelbob.xyz",
       "https://searx.fmac.xyz",
+      "https://searx.garudalinux.org",
       "https://searx.gnous.eu",
       "https://searx.mha.fi",
       "https://searx.namejeff.xyz",


### PR DESCRIPTION
Added two new instances for SearxNG:
- searx.garudalinux.org
- google.censors.us