### PR TITLE
Fix incorrect localization

### DIFF
--- a/src/pages/options/youtube/youtube.html
+++ b/src/pages/options/youtube/youtube.html
@@ -182,7 +182,7 @@
           <input class="volume" type="range" min="0" max="100" step="1">
         </div>
         <div class="some-block option-block">
-          <h4 data-localise="__MSG_prefDashQuality__">Default comments</h4>
+          <h4 data-localise="__MSG_defaultComments__">Default comments</h4>
           <select class="comments[0]">
             <option value="" data-localise="__MSG_none__">none</option>
             <option value="youtube">YouTube</option>


### PR DESCRIPTION
"Default Comments" in Invidious Custom Settings was mislabeled as "Preferred DASH video quality" due to incorrect localization. Changed `data-localise="__MSG_prefDashQuality__"` to `data-localise="__MSG_defaultComments__"`.