### PR TITLE
Fix incorrect localization

### DIFF
--- a/pug/options/youtube/youtube.pug
+++ b/pug/options/youtube/youtube.pug
@@ -124,7 +124,7 @@ body.option(dir="auto")
                     input.volume(type="range" min="0" max="100" step="1")
 
                 .some-block.option-block
-                    h4(data-localise="__MSG_prefDashQuality__") Default comments
+                    h4(data-localise="__MSG_defaultComments__") Default comments
                     select(class="comments[0]")
                         option(value="" data-localise="__MSG_none__") none
                         option(value="youtube") YouTube


### PR DESCRIPTION
"Default Comments" in Invidious Custom Settings was mislabeled as "Preferred DASH video quality" due to incorrect localization. Changed `data-localise="__MSG_prefDashQuality__"` to `data-localise="__MSG_defaultComments__"`.