### PR TITLE
Use constant name prefix for all services

### DIFF
--- a/src/assets/javascripts/helpers/imgur.js
+++ b/src/assets/javascripts/helpers/imgur.js
@@ -4,6 +4,8 @@ import commonHelper from './common.js'
 
 const targets = /^https?:\/{2}([im]\.)?imgur\.com(\/|$)/
 
+const NAME = "imgur";
+
 let redirects = {
     "rimgo": {
         "normal": [],
@@ -194,6 +196,7 @@ async function init() {
 }
 
 export default {
+    NAME,
     getRedirects,
     setRedirects,
 

--- a/src/assets/javascripts/helpers/instagram.js
+++ b/src/assets/javascripts/helpers/instagram.js
@@ -5,6 +5,9 @@ const targets = [
   "instagram.com",
   "www.instagram.com",
 ];
+
+const NAME = "instagram";
+
 let redirects = {
   "bibliogram": {
     "normal": [],
@@ -247,6 +250,7 @@ async function init() {
 }
 
 export default {
+  NAME,
   getRedirects,
   setRedirects,
 

--- a/src/assets/javascripts/helpers/lbry.js
+++ b/src/assets/javascripts/helpers/lbry.js
@@ -4,6 +4,8 @@ import commonHelper from './common.js'
 
 let targets = ["odysee.com"];
 
+const NAME = "lbry";
+
 let redirects = {
     "librarian": {
         "normal": [
@@ -154,7 +156,7 @@ async function init() {
 }
 
 export default {
-
+    NAME,
     getRedirects,
     setRedirects,
     switchInstance,

--- a/src/assets/javascripts/helpers/maps.js
+++ b/src/assets/javascripts/helpers/maps.js
@@ -5,6 +5,8 @@ import commonHelper from './common.js'
 
 const targets = /^https?:\/{2}(((www|maps)\.)?(google\.).*(\/maps)|maps\.(google\.).*)/;
 
+const NAME = "privacyMaps";
+
 let redirects = {
   'osm': {
     "normal": [
@@ -222,6 +224,7 @@ async function init() {
 }
 
 export default {
+  NAME,
   redirect,
   init,
   initDefaults,

--- a/src/assets/javascripts/helpers/medium.js
+++ b/src/assets/javascripts/helpers/medium.js
@@ -28,6 +28,8 @@ const targets = [
   /^ writingcooperative\.com /,
 ];
 
+const NAME = "medium";
+
 let redirects = {
   "scribe": {
     "normal": [],
@@ -181,6 +183,7 @@ async function init() {
 }
 
 export default {
+  NAME,
   targets,
 
   getRedirects,

--- a/src/assets/javascripts/helpers/peertube.js
+++ b/src/assets/javascripts/helpers/peertube.js
@@ -4,6 +4,8 @@ import commonHelper from './common.js'
 
 let targets = [];
 
+const NAME = "peertube";
+
 let redirects = {
     "simpleertube": {
         "normal": [
@@ -152,7 +154,7 @@ async function init() {
 }
 
 export default {
-
+    NAME,
     getRedirects,
     setRedirects,
 

--- a/src/assets/javascripts/helpers/reddit.js
+++ b/src/assets/javascripts/helpers/reddit.js
@@ -2,6 +2,8 @@ window.browser = window.browser || window.chrome;
 
 import commonHelper from './common.js'
 
+const NAME = "reddit";
+
 const targets = [
   /^https?:\/{2}(www\.|old\.|np\.|new\.|amp\.|)reddit\.com/,
   /^https?:\/{2}(i\.|preview\.)redd\.it/,
@@ -519,6 +521,7 @@ async function init() {
 }
 
 export default {
+  NAME,
   targets,
   getRedirects,
   getCustomRedirects,

--- a/src/assets/javascripts/helpers/search.js
+++ b/src/assets/javascripts/helpers/search.js
@@ -10,6 +10,9 @@ const targets = [
 
   /^https?:\/{2}libredirect\.invalid/,
 ];
+
+const NAME = "privacySearch";
+
 let redirects = {
   "searx": {
     "normal": [],
@@ -420,7 +423,7 @@ async function init() {
 }
 
 export default {
-
+  NAME,
   setSearxRedirects,
   setSearxngRedirects,
   setWhoogleRedirects,

--- a/src/assets/javascripts/helpers/sendTargets.js
+++ b/src/assets/javascripts/helpers/sendTargets.js
@@ -8,6 +8,8 @@ const targets = [
     /^https?:\/{2}sendfiles\.online\/$/
 ];
 
+const NAME = "sendFile";
+
 let redirects = {
     "send": {
         "normal": [],
@@ -144,6 +146,7 @@ async function init() {
 }
 
 export default {
+    NAME,
     getRedirects,
     setRedirects,
 

--- a/src/assets/javascripts/helpers/speedtest.js
+++ b/src/assets/javascripts/helpers/speedtest.js
@@ -6,6 +6,8 @@ const targets = [
     /^https?:\/{2}(www\.|)speedtest\.net\/$/
 ];
 
+const NAME = "speedtest";
+
 let redirects = {
     "librespeed": {
         "normal": [
@@ -104,6 +106,7 @@ async function init() {
 }
 
 export default {
+    NAME,
     getRedirects,
     setRedirects,
 

--- a/src/assets/javascripts/helpers/spotify.js
+++ b/src/assets/javascripts/helpers/spotify.js
@@ -6,6 +6,8 @@ let targets = [
     /^https?:\/{2}(open\.|)spotify\.com/,
 ];
 
+const NAME = "spotify";
+
 let redirects = {
     "soju": {
         "normal": [
@@ -97,6 +99,7 @@ async function init() {
 }
 
 export default {
+    NAME,
     setRedirects,
 
     switchInstance,

--- a/src/assets/javascripts/helpers/tiktok.js
+++ b/src/assets/javascripts/helpers/tiktok.js
@@ -6,6 +6,8 @@ const targets = [
     /^https?:\/{2}(www\.|)tiktok\.com.*/
 ];
 
+const NAME = "tiktok";
+
 let redirects = {
     "proxiTok": {
         "normal": [],

--- a/src/assets/javascripts/helpers/translate/translate.js
+++ b/src/assets/javascripts/helpers/translate/translate.js
@@ -6,6 +6,8 @@ const targets = [
   /^https?:\/{2}translate\.google(\.[a-z]{2,3}){1,2}\//,
 ];
 
+const NAME = "privacyTranslate";
+
 let redirects = {
   "simplyTranslate": {
     "normal": [],
@@ -289,6 +291,7 @@ async function init() {
 }
 
 export default {
+  NAME,
   getRedirects,
 
   isTranslateRedirects,

--- a/src/assets/javascripts/helpers/twitter.js
+++ b/src/assets/javascripts/helpers/twitter.js
@@ -9,6 +9,8 @@ const targets = [
   /^https?:\/{2}t\.co/
 ];
 
+const NAME = "twitter";
+
 let redirects = {
   "nitter": {
     "normal": [],
@@ -332,6 +334,7 @@ async function init() {
 }
 
 export default {
+  NAME,
   getRedirects,
   setRedirects,
   reverse,

--- a/src/assets/javascripts/helpers/wikipedia.js
+++ b/src/assets/javascripts/helpers/wikipedia.js
@@ -4,6 +4,8 @@ import commonHelper from './common.js'
 
 const targets = /^https?:\/{2}(([a-z]{1,}\.){0,})wikipedia\.org/
 
+const NAME = "wikipedia";
+
 let redirects = {
   "wikiless": {
     "normal": [],
@@ -205,6 +207,7 @@ async function init() {
 }
 
 export default {
+  NAME,
   getRedirects,
   setRedirects,
 

--- a/src/assets/javascripts/helpers/youtube/youtube.js
+++ b/src/assets/javascripts/helpers/youtube/youtube.js
@@ -19,6 +19,9 @@ const targets = [
 
   /^https?:\/{2}(www\.|)(youtube|youtube-nocookie)\.com\/embed\/..*/,
 ];
+
+const NAME = "youtube";
+
 let redirects = {
   "invidious": {
     "normal": [],
@@ -440,6 +443,7 @@ let
   initInvidiousCookies = invidious.initInvidiousCookies;
 
 export default {
+  NAME,
   initPipedLocalStorage,
   initPipedMaterialLocalStorage,
   initInvidiousCookies,

--- a/src/assets/javascripts/helpers/youtubeMusic.js
+++ b/src/assets/javascripts/helpers/youtubeMusic.js
@@ -7,6 +7,9 @@ window.browser = window.browser || window.chrome;
 const targets = [
     /^https?:\/{2}music\.youtube\.com(\/.*|$)/,
 ];
+
+const NAME = "youtubeMusic";
+
 let redirects = {
     "beatbump": {
         "normal": [
@@ -94,6 +97,7 @@ async function init() {
 }
 
 export default {
+    NAME,
     getRedirects,
     redirect,
     isYoutubeMusic,


### PR DESCRIPTION
This change will allow us not to invent variables to access, like this
https://github.com/libredirect/libredirect/blob/8d4e15af069344894110299e3657862697e50aeb/src/pages/popup/popup.js#L27-L45
Also can used as prefix for storage keys
```js
const NAME = "imgur";
const DISABLED = "disable" + NAME; 
const PROTOCOL = NAME + "Protocol"; 
const REDIRECTS =  NAME + "Redirects";
```
instead of
https://github.com/libredirect/libredirect/blob/f2b114256d703f5b1c57c032fde29c4ba9a3326a/src/assets/javascripts/helpers/imgur.js#L146-L148