### PR TITLE
drop all instances from 'alefvanoon.xyz'

### DIFF
--- a/src/instances/data.json
+++ b/src/instances/data.json
@@ -159,7 +159,6 @@
       "https://bibliogram.froth.zone",
       "https://insta.trom.tf",
       "https://insta.tromdienste.de",
-      "https://biblio.alefvanoon.xyz",
       "https://ig.beparanoid.de",
       "https://bibliogram.privacydev.net",
       "https://bib.actionsack.com"
@@ -254,7 +253,6 @@
       "https://teddit.domain.glass",
       "https://snoo.ioens.is",
       "https://teddit.httpjames.space",
-      "https://teddit.alefvanoon.xyz",
       "https://incogsnoo.com",
       "https://teddit.pussthecat.org",
       "https://reddit.lol",
@@ -276,7 +274,6 @@
   "wikiless": {
     "normal": [
       "https://wikiless.org",
-      "https://wikiless.alefvanoon.xyz",
       "https://wikiless.sethforprivacy.com",
       "https://wiki.604kph.xyz",
       "https://wikiless.lunar.icu",
@@ -333,7 +330,6 @@
   "lingva": {
     "normal": [
       "https://lingva.ml",
-      "https://translate.alefvanoon.xyz",
       "https://translate.igna.rocks",
       "https://lingva.pussthecat.org",
       "https://translate.datatunnel.xyz",


### PR DESCRIPTION
The domain has expired and is currently for sale at auction.