### PR TITLE
Remove instances

### DIFF
--- a/src/instances/data.json
+++ b/src/instances/data.json
@@ -166,7 +166,6 @@
       "https://bibliogram.froth.zone",
       "https://insta.trom.tf",
       "https://insta.tromdienste.de",
-      "https://biblio.alefvanoon.xyz",
       "https://ig.beparanoid.de",
       "https://bibliogram.privacydev.net",
       "https://bib.actionsack.com"
@@ -261,7 +260,6 @@
       "https://teddit.domain.glass",
       "https://snoo.ioens.is",
       "https://teddit.httpjames.space",
-      "https://teddit.alefvanoon.xyz",
       "https://incogsnoo.com",
       "https://teddit.pussthecat.org",
       "https://reddit.lol",
@@ -283,7 +281,6 @@
   "wikiless": {
     "normal": [
       "https://wikiless.org",
-      "https://wikiless.alefvanoon.xyz",
       "https://wikiless.sethforprivacy.com",
       "https://wiki.604kph.xyz",
       "https://wikiless.lunar.icu",
@@ -340,7 +337,6 @@
   "lingva": {
     "normal": [
       "https://lingva.ml",
-      "https://translate.alefvanoon.xyz",
       "https://translate.igna.rocks",
       "https://lingva.pussthecat.org",
       "https://translate.datatunnel.xyz",

--- a/src/instances/data.json
+++ b/src/instances/data.json
@@ -340,7 +340,6 @@
       "https://translate.igna.rocks",
       "https://lingva.pussthecat.org",
       "https://translate.datatunnel.xyz",
-      "https://lingva.esmailelbob.xyz",
       "https://translate.plausibility.cloud",
       "https://lingva.lunar.icu"
     ],


### PR DESCRIPTION
- alefvanoon.xyz says the domain is for sale

- lingva.esmailelbob.xyz isn't hosted anymore, it redirects to simplytranslate.esmailelbob.xyz