### PR TITLE
Low latency fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 	},
 	"homepage": "https://libredirect.codeberg.page",
 	"devDependencies": {
+		"eslint": "^8.25.0",
 		"prettier": "2.7.1",
 		"web-ext": "^7.2.0"
 	},

--- a/src/pages/options/index.html
+++ b/src/pages/options/index.html
@@ -179,6 +179,9 @@
       <output id="latency-output" for="latencyInput" name="latencyOutput"></output>
       <input id="latency-input" type="range" min="50" max="5000" value="1000" name="latencyInput" step="50">
     </div>
+    <div class="some-block option-block">
+      <h4 data-localise="__MSG_fallbackToFastest__">Fallback to fastest instance if none meet the set threshold</h4>
+      <input id="fallback-to-fastest" type="checkbox">
   </form>
   <div class="some-block option-block">
     <h4 data-localise="__MSG_exceptions__"></h4>

--- a/src/pages/options/widgets/general.ejs
+++ b/src/pages/options/widgets/general.ejs
@@ -37,6 +37,9 @@
     </div>
   </form>
   <div class="some-block option-block">
+  <h4 data-localise="__MSG_fallbackToFastest__">Fallback to fastest instance if none meet the set threshold</h4>                                             
+    <input id="fallback-to-fastest" type="checkbox">
+  <div class="some-block option-block">
     <h4 data-localise="__MSG_exceptions__"></h4>
   </div>
   <form id="custom-exceptions-instance-form">

--- a/src/pages/options/widgets/general.js
+++ b/src/pages/options/widgets/general.js
@@ -197,13 +197,22 @@ browser.storage.local.get("options", r => {
 	} else {
 		networkFallbackCheckbox.disabled = false
 	}
-
-  if (fallbackToFastest.checked) {
-    //get the fastest instance, and set the latency threshold to the latency of that instance
+async function fallbackFastest() {
+  if (options.fallbackToFastest) {
     let fastestInstance = await getFastestInstance()
-    latencyInput.value = fastestInstance.latency
-    latencyOutput.value = fastestInstance.latency
+    if (fastestInstance) {
+      latencyInput.value = fastestInstance.latency
+      latencyOutput.value = fastestInstance.latency
+      let instance = fastestInstance.instance
+      let service = fastestInstance.service
+      let url = servicesHelper.getRedirectUrl(service, instance)
+      browser.tabs.query({ active: true, currentWindow: true }, tabs => {
+        browser.tabs.update(tabs[0].id, { url: url })
+      })
+    }
   }
+}
+
 
   async function getFastestInstance() {
     let fastestInstance = null


### PR DESCRIPTION
I would like to introduce the ability to make the extension use the fastest instance as the fallback if the user sets the latency threshold is set to a too low value (i.e. there are no instances for which the latency is lower than the set value), please pardon the confusion from erroneous branch name.
Issues that need addressing:

1. The switch does not show up in the dark mode. 
2. It is located at the bottom of the settings screen, while it should be right below the latency slider.
