### PR TITLE
Update fetch url for Libreddit instances.

### DIFF
--- a/src/instances/get_instances.py
+++ b/src/instances/get_instances.py
@@ -311,7 +311,7 @@ def bibliogram():
 
 
 def libreddit():
-    fetchJsonList('libreddit', 'Libreddit', 'https://github.com/libbacon/libreddit-instances/raw/master/instances.json', {'clearnet': 'url', 'tor': 'onion', 'i2p': 'i2p', 'loki': None}, True)
+    fetchJsonList('libreddit', 'Libreddit', 'https://github.com/ferritreader/libreddit-instances/raw/master/instances.json', {'clearnet': 'url', 'tor': 'onion', 'i2p': 'i2p', 'loki': None}, True)
 
 
 def teddit():


### PR DESCRIPTION
The libbacon project org has changed its name to [ferritreader](https://github.com/ferritreader). This PR makes the appropriate change to src/instances/get_instances.py to fetch the libreddit instances JSON from the libreddit-instances repo in the ferritreader project.