### PR TITLE
Fix link to libreddit-instances JSON.

### DIFF
--- a/src/instances/get_instances.py
+++ b/src/instances/get_instances.py
@@ -334,7 +334,7 @@ def bibliogram():
 
 
 def libreddit():
-    fetchJsonList('libreddit', 'Libreddit', 'https://github.com/ferritreader/libreddit-instances/raw/master/instances.json',
+    fetchJsonList('libreddit', 'Libreddit', 'https://github.com/libreddit/libreddit-instances/raw/master/instances.json',
                   {'clearnet': 'url', 'tor': 'onion', 'i2p': 'i2p', 'loki': None}, True)
 
 


### PR DESCRIPTION
With the resumption of the Libreddit project, the repo containing the instances that I started in [ferritreader](https://github.com/ferritreader) has moved to [libreddit/libreddit-instances](https://github.com/libreddit/libreddit-instances). This commit fixes the URL for libreddit instances to point to that repo.