### PR TITLE
Remove Ferrit.

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -290,26 +290,6 @@
 					},
 					"name": "Teddit",
 					"instanceList": true
-				},
-				"ferrit": {
-					"preferences": {
-						"cookies": [
-							"theme",
-							"front_page",
-							"layout",
-							"wide",
-							"post_sort",
-							"comment_sort",
-							"show_nsfw",
-							"autoplay_videos",
-							"use_hls",
-							"hide_hls_notification",
-							"subscriptions",
-							"filters"
-						]
-					},
-					"name": "Ferrit",
-					"instanceList": true
 				}
 			},
 			"targets": [
@@ -319,7 +299,7 @@
 			"name": "Reddit",
 			"options": {
 				"enabled": true,
-				"frontend": "ferrit"
+				"frontend": "libreddit"
 			},
 			"imageType": "png",
 			"embeddable": false,

--- a/src/instances/get_instances.py
+++ b/src/instances/get_instances.py
@@ -343,11 +343,6 @@ def teddit():
                   {'clearnet': 'url', 'tor': 'onion', 'i2p': 'i2p', 'loki': None}, False)
 
 
-def ferrit():
-    fetchJsonList('ferrit', 'Ferrit', 'https://raw.githubusercontent.com/ferritreader/ferrit-instances/master/instances.json',
-                  {'clearnet': 'url', 'tor': 'onion', 'i2p': 'i2p', 'loki': None}, True)
-
-
 def wikiless():
     fetchJsonList('wikiless', 'Wikiless', 'https://wikiless.org/instances.json',
                   {'clearnet': 'url', 'tor': 'onion', 'i2p': 'i2p', 'loki': None}, False)
@@ -505,7 +500,6 @@ nitter()
 bibliogram()
 libreddit()
 teddit()
-ferrit()
 wikiless()
 scribe()
 quetre()


### PR DESCRIPTION
[Ferrit has been discontinued with the resumption of the Reddit project.](https://github.com/ferritreader/ferrit/discussions/61) This PR removes all references to Ferrit in `src/config/config.json` and amends `src/instances/get_instances.py` not to pull the list of Ferrit instances anymore. (The instances repo has been deleted.)