### PR TITLE
Fix instance fetching for BreezeWiki

### DIFF
--- a/src/instances/get_instances.py
+++ b/src/instances/get_instances.py
@@ -442,9 +442,7 @@ def libreTranslate():
 
 
 def breezeWiki():
-    fetchRegexList('breezeWiki', 'BreezeWiki', 'https://gitdab.com/cadence/breezewiki-docs/raw/branch/main/docs.scrbl',
-                   r"\(\"[^\n\s\r\t\f\v\"]+\" \"https?:\/{2}(?:[^\s\/]+\.)+[a-zA-Z0-9]+(?:\/[^\s\/]+)*\" \"(https?:\/{2}(?:[^\s\/]+\.)+[a-zA-Z0-9]+(?:\/[^\s\/]+)*)\"\)")
-
+    fetchJsonList('breezeWiki', 'BreezeWiki', 'https://docs.breezewiki.com/files/instances.json', 'instance', False)
 
 def privateBin():
     fetchJsonList('privateBin', 'PrivateBin',


### PR DESCRIPTION
The official instance list was moved to a JSON file, as found on https://docs.breezewiki.com/Links.html#%28part._.Instances%29