### PR TITLE
services: Fix `anonymousOverflow` redirect when answers are linked

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -367,7 +367,7 @@ function redirect(url, type, initiator, forceRedirection) {
 			if (url.hostname.match(/^[a-zA-Z0-9-]+\.(?:fandom|wikia)\.com/)) {
 				wiki = url.hostname.match(/^[a-zA-Z0-9-]+(?=\.(?:fandom|wikia)\.com)/)
 				if (wiki == "www" || !wiki) wiki = ""
-				else wiki = `/${wiki}`;
+				else wiki = `/${wiki}`
 				urlpath = url.pathname
 			} else {
 				wiki = url.pathname.match(/(?<=wiki\/w:c:)[a-zA-Z0-9-]+(?=:)/)
@@ -406,9 +406,9 @@ function redirect(url, type, initiator, forceRedirection) {
 		case "neuters": {
 			const p = url.pathname
 			if (p.startsWith('/article/') || p.startsWith('/pf/') || p.startsWith('/arc/') || p.startsWith('/resizer/')) {
-				return null;
+				return null
 			}
-			return `${randomInstance}${p}`;
+			return `${randomInstance}${p}`
 		}
 		case "dumb": {
 			if (url.pathname.endsWith('-lyrics')) return `${randomInstance}${url.pathname}`
@@ -419,7 +419,8 @@ function redirect(url, type, initiator, forceRedirection) {
 		}
 		case "anonymousOverflow": {
 			if (!url.pathname.startsWith('/questions') && url.pathname != '/') return
-			return `${randomInstance}${url.pathname}${url.search}`
+			const threadID = /\/\d+(?=[?&#/]|$)/.exec(url.pathname)?.[0]
+			return `${randomInstance}${threadID ? '/questions' + threadID : url.pathname}${url.search}`
 		}
 		case "biblioReads": {
 			if (!url.pathname.startsWith('/book/show/') && url.pathname != '/') return


### PR DESCRIPTION
Currently, if an answer is linked in the url, the url expands to 2 ids, the first one being the thread, and the second being the answer. Anonymous Overflow at the moment, doesn't support linking to answers, you'll just get a `404 page not found`, `url.hash`ing doesn't work either (or rather, it doesn't 404, but it doesn't actually link you to the answer), this PR fixes this by grabbing the thread ID directly.
example:
https://stackoverflow.com/a/11227902
https://stackoverflow.com/questions/11227809/why-is-processing-a-sorted-array-faster-than-processing-an-unsorted-array/11227902