### PR TITLE
Preserve URL hash on wikiless redirection

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -475,7 +475,7 @@ function redirect(url, type, initiator, forceRedirection) {
 				// wikiless doesn't have mobile view support yet
 			}
 			for (let i = 0; i < GETArguments.length; i++) link += (i == 0 ? "?" : "&") + GETArguments[i][0] + "=" + GETArguments[i][1]
-			return link
+			return link + url.hash
 		}
 		case "proxiTok": {
 			if (url.pathname.startsWith('/email')) return


### PR DESCRIPTION
You can link to sub-sections of a Wikipedia article using URL hash, such as in `https://en.wikipedia.org/wiki/Survivorship_bias#Military`. This also works on wikiless. This PR adds requested hash to redirected URLs.