### PR TITLE
Fix YouTube livestream chat breaking on embed only mode

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -155,7 +155,19 @@ function redirect(url, type, initiator, forceRedirection) {
 		case "freetube": {
 			return `freetube://https://youtu.be${url.pathname}${url.search}`.replace(/watch\?v=/, "")
 		}
+		case "invidious":
+		case "piped":
+		case "pipedMaterial":
+		case "cloudtube": {
+			if (url.pathname == "/live_chat") {
+				return null;
+			}
+			return `${randomInstance}${url.pathname}${url.search}`;
+		}
 		case "poketube": {
+			if (url.pathname == "/live_chat") {
+				return null;
+			}
 			if (url.pathname.startsWith('/channel')) {
 				const reg = /\/channel\/(.*)\/?$/.exec(url.pathname)
 				if (reg) {

--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -159,13 +159,13 @@ function redirect(url, type, initiator, forceRedirection) {
 		case "piped":
 		case "pipedMaterial":
 		case "cloudtube": {
-			if (url.pathname == "/live_chat") {
+			if (url.pathname.startsWith("/live_chat")) {
 				return null;
 			}
 			return `${randomInstance}${url.pathname}${url.search}`;
 		}
 		case "poketube": {
-			if (url.pathname == "/live_chat") {
+			if (url.pathname.startsWith("/live_chat")) {
 				return null;
 			}
 			if (url.pathname.startsWith('/channel')) {


### PR DESCRIPTION
YouTube live chat on live streams and replays uses an iframe to display the chat alongside the video, so Libredirect will try to redirect it when it is set to only redirect YouTube embeds. All YouTube services will 404 when trying to redirect the chat. This PR adds an exception for live chat pages when redirecting Invidious, Piped (Material), CloudTube, and PokeTube.