### PR TITLE
Update config.json - Add threads.com

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1393,7 +1393,7 @@
         }
       },
       "targets": [
-        "^https?:\\/{2}(www\\.)?threads\\.net"
+        "^https?:\\/{2}(www\\.)?threads\\.(net|com)"
       ],
       "name": "Threads",
       "options": {


### PR DESCRIPTION
Shoelace was added on #932 .
However, Meta has set `threads.com` is an alternative host to `threads.net`, and it's not being caught by Libredirect.
This PR adds the new domain.