### PR TITLE
Added Lumo by Proton as a ChatGPT frontend

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -597,6 +597,9 @@ function rewrite(url, originUrl, frontend, randomInstance, type) {
     case "duckDuckGoAiChat":
       return "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=1"
 
+    case "protonLumo":
+      return "https://lumo.proton.me/"
+
     case "soundcloak":
       if (url.pathname.startsWith("/feed") || url.pathname.startsWith("/stream")) {
         // this feature requires authentication and is unsupported, so just redirect to main page

--- a/src/config.json
+++ b/src/config.json
@@ -231,6 +231,11 @@
           "name": "DuckDuckGo AI Chat",
           "instanceList": false,
           "url": "https://duckduckgo.com/duckduckgo-help-pages/aichat/"
+        },
+        "protonLumo": {
+          "name": "Lumo by Proton",
+          "instanceList": false,
+          "url": "https://lumo.proton.me/"
         }
       },
       "targets": ["^https?:\\/{2}chatgpt\\.com"],


### PR DESCRIPTION
Added Lumo as a ChatGPT alternative. It's made by the [Proton](https://lumo.proton.me/about) team and seems to have a business model that doesn't rely on exploiting user data.