### PR TITLE
Added LibreMDB, 4Get, Wikimore & Cryptpad instances

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -907,13 +907,13 @@ const defaultInstances = {
   small: ["https://small.bloat.cat"],
   freedium: ["https://freedium.cfd"],
   quetre: ["https://quetre.iket.me"],
-  libremdb: ["https://libremdb.iket.me"],
+  libremdb: ["https://libremdb.iket.me", "https://libremdb.fbin.in"],
   simplyTranslate: ["https://simplytranslate.org"],
-  translite: ["https://tl.bloat.cat"],
+  translite: ["https://tl.bloat.cat", "https://tl.fbin.in"],
   rens: ["https://ren.maid.zone"],
   mozhi: ["https://mozhi.aryak.me"],
   searxng: ["https://nyc1.sx.ggtyler.dev"],
-  "4get": ["https://4get.ca"],
+  "4get": ["https://4get.ca", "https://4g.flossboxin.org.in", "https://fossq.com"],
   websurfx: ["https://alamin655-spacex.hf.space"],
   rimgo: ["https://rimgo.vern.cc"],
   hyperpipe: ["https://hyperpipe.surge.sh"],
@@ -967,9 +967,9 @@ const defaultInstances = {
   koub: ["https://koub.clovius.club"],
   soundcloak: ["https://soundcloak.fly.dev"],
   gocook: ["https://cook.adminforge.de"],
-  wikimore: ["https://wikimore.private.coffee"],
+  wikimore: ["https://wikimore.private.coffee", "https://w.fbin.in"],
   libreTranslate: ["https://libretranslate.com"],
-  cryptPad: ["https://cryptpad.org"],
+  cryptPad: ["https://cryptpad.org", "https://cpad.fbin.in"],
   phantom: ["https://phantom.kuuro.net"]
 }
 

--- a/src/config.json
+++ b/src/config.json
@@ -1076,7 +1076,7 @@
         "wikiless": {
           "name": "Wikiless",
           "instanceList": true,
-          "url": "https://wikiless.org"
+          "url": "https://github.com/V4NT-ORG/Wikiless-Reborn/"
         },
         "wikimore": {
           "name": "Wikimore",


### PR DESCRIPTION
Added my self hosted LibreMDB, 4Get, Wikimore & Cryptpad instances to the list. Also, corrected the Wikiless default URL (repo). The repo in https://github.com/Metastem/wikiless/wiki redirects to https://github.com/V4NT-ORG/Wikiless-Reborn/wiki for anything. Hence the change from wikiless.org (which is no longer available it seems). Although wikiless.org has an IP of 65.109.174.25, but it keeps timing out.