### PR TITLE
Update page references to libredirect.manerakai.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A browser extension that redirects YouTube, Twitter, TikTok... requests to alter
     <img src ="./img/badge-amo.png" height=60 >
 </a>
 &nbsp;
-<a href="https://libredirect.github.io/download_chromium.html">
+<a href="https://libredirect.manerakai.com/download_chromium.html">
     <img src ="./img/badge-chromium.png" height=60 >
 </a>
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "bugs": {
     "url": "https://github.com/libredirect/libredirect/issues"
   },
-  "homepage": "https://libredirect.github.io",
+  "homepage": "https://libredirect.manerakai.com",
   "devDependencies": {
     "prettier": "3.3.3"
   },

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -138,7 +138,7 @@
         "message": "احجب"
     },
     "searchHint": {
-        "message": "اجعل LibRedirect محرك البحث الافتراضي. لمعرفة كيفية القيام بذلك في متصفحات كروميوم، انقر <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>هنا</a>."
+        "message": "اجعل LibRedirect محرك البحث الافتراضي. لمعرفة كيفية القيام بذلك في متصفحات كروميوم، انقر <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>هنا</a>."
     },
     "redirect": {
         "message": "أعد التوجيه"

--- a/src/_locales/bn/messages.json
+++ b/src/_locales/bn/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "লিবরিডাইরেক্টকে সহজাত অনুসন্ধান যন্ত্র হিসেবে রাখো। ক্রোমিয়াম ব্রাউজারে এটা করার জন্য <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>এখানে টিপ দাও</a>।"
+        "message": "লিবরিডাইরেক্টকে সহজাত অনুসন্ধান যন্ত্র হিসেবে রাখো। ক্রোমিয়াম ব্রাউজারে এটা করার জন্য <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>এখানে টিপ দাও</a>।"
     },
     "redirect": {
         "message": "পুনর্নির্দেশ"

--- a/src/_locales/bs/messages.json
+++ b/src/_locales/bs/messages.json
@@ -137,7 +137,7 @@
         "message": "Blokirajte"
     },
     "searchHint": {
-        "message": "Postavite LibRedirect kao standardni tražionik. <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>Ovdje</a> pogledajte kako se to radi u Kromijum mrežnom pregledniku."
+        "message": "Postavite LibRedirect kao standardni tražionik. <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>Ovdje</a> pogledajte kako se to radi u Kromijum mrežnom pregledniku."
     },
     "redirect": {
         "message": "Preusmjerite"

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -137,7 +137,7 @@
         "message": "Blokovat"
     },
     "searchHint": {
-        "message": "Nastavte LibRedirect jako výchozí vyhledávač. Návod pro Chromium prohlížeče naleznete <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>zde</a>."
+        "message": "Nastavte LibRedirect jako výchozí vyhledávač. Návod pro Chromium prohlížeče naleznete <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>zde</a>."
     },
     "redirect": {
         "message": "Přesměrovat"

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Legen Sie LibRedirect als Standard-Suchmaschine fest. Wie man das in Chromium-Browsern macht, erfahren Sie <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>hier</a>."
+        "message": "Legen Sie LibRedirect als Standard-Suchmaschine fest. Wie man das in Chromium-Browsern macht, erfahren Sie <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>hier</a>."
     },
     "redirect": {
         "message": "Umleiten"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
+        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
     },
     "redirect": {
         "message": "Redirect"

--- a/src/_locales/eo/messages.json
+++ b/src/_locales/eo/messages.json
@@ -137,7 +137,7 @@
         "message": "Bloki"
     },
     "searchHint": {
-        "message": "Agordu LibRedirect·on kiel vian defaŭltan sercilon. Por kiel fari ĝin en Chromium-bazitaj retumiloj (angle), <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>alklaku tien</a>."
+        "message": "Agordu LibRedirect·on kiel vian defaŭltan sercilon. Por kiel fari ĝin en Chromium-bazitaj retumiloj (angle), <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>alklaku tien</a>."
     },
     "redirect": {
         "message": "Alidirekti"

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -137,7 +137,7 @@
         "message": "Bloquear"
     },
     "searchHint": {
-        "message": "Establece LibRedirect como motor de búsqueda predeterminado. Para saber cómo hacerlo en los navegadores Chromium, haz clic <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>aquí</a>."
+        "message": "Establece LibRedirect como motor de búsqueda predeterminado. Para saber cómo hacerlo en los navegadores Chromium, haz clic <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>aquí</a>."
     },
     "redirect": {
         "message": "Redirigir"

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -132,6 +132,6 @@
         "message": "دریافت نمونه‌های عمومی"
     },
     "searchHint": {
-        "message": "LIBREDIRECT را به عنوان موتور جستجوی پیش‌فرض تنظیم کنید. برای نحوه انجام در مرورگرهای کروم ، روی <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>اینجا</a> ضربه بزنید."
+        "message": "LIBREDIRECT را به عنوان موتور جستجوی پیش‌فرض تنظیم کنید. برای نحوه انجام در مرورگرهای کروم ، روی <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>اینجا</a> ضربه بزنید."
     }
 }

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -137,7 +137,7 @@
         "message": "Estä"
     },
     "searchHint": {
-        "message": "Aseta LibRedirect oletushakukoneeksi. Ohjeita varten chromium-selaimissa, paina <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>tästä</a>."
+        "message": "Aseta LibRedirect oletushakukoneeksi. Ohjeita varten chromium-selaimissa, paina <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>tästä</a>."
     },
     "redirect": {
         "message": "Uudelleenohjaa"

--- a/src/_locales/fil/messages.json
+++ b/src/_locales/fil/messages.json
@@ -6,7 +6,7 @@
         "message": "Kunin ang mga publikong instansya"
     },
     "searchHint": {
-        "message": "Itakda ang LibRedirect bilang Default na Search Engine. Para sa kung paano gawin sa mga Chromium browser, mag-click <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>dito</a>."
+        "message": "Itakda ang LibRedirect bilang Default na Search Engine. Para sa kung paano gawin sa mga Chromium browser, mag-click <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>dito</a>."
     },
     "unsupportedIframesHandling": {
         "message": "Pag-handle sa mga hindi sinusuportahang embed"

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -137,7 +137,7 @@
         "message": "Bloquer"
     },
     "searchHint": {
-        "message": "Paramétrez LibRedirect pour être votre moteur de recherche par défaut. Pour savoir comment faire sur un navigateur chromium, cliquez <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>ici</a>."
+        "message": "Paramétrez LibRedirect pour être votre moteur de recherche par défaut. Pour savoir comment faire sur un navigateur chromium, cliquez <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>ici</a>."
     },
     "redirect": {
         "message": "Rediriger"

--- a/src/_locales/gl/messages.json
+++ b/src/_locales/gl/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Establece a LibRedirect como Motor de Busca predeterminado. Para facelo nos navegadores chromium, preme <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>aquí</a>."
+        "message": "Establece a LibRedirect como Motor de Busca predeterminado. Para facelo nos navegadores chromium, preme <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>aquí</a>."
     },
     "redirect": {
         "message": "Redirect"

--- a/src/_locales/hr/messages.json
+++ b/src/_locales/hr/messages.json
@@ -137,7 +137,7 @@
         "message": "Blokiraj"
     },
     "searchHint": {
-        "message": "Postavi LibRedirect kao standardnu tražilicu. <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>Ovdje</a> pogledaj kako se to radi u Chromium web pregledniku."
+        "message": "Postavi LibRedirect kao standardnu tražilicu. <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>Ovdje</a> pogledaj kako se to radi u Chromium web pregledniku."
     },
     "redirect": {
         "message": "Preusmjeri"

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -126,7 +126,7 @@
         "message": "Megkerülés"
     },
     "searchHint": {
-        "message": "LibRedirect beállítása alapértelmezett keresőmotornak. A Chromium böngészőkben történő művelethez kattintson <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>ide</a>."
+        "message": "LibRedirect beállítása alapértelmezett keresőmotornak. A Chromium böngészőkben történő művelethez kattintson <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>ide</a>."
     },
     "searchService": {
         "message": "Szolgáltatás keresése"

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Tetapkan LibRedirect sebagai Mesin Pencari Default. Untuk cara melakukannya di browser kromium, klik<a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
+        "message": "Tetapkan LibRedirect sebagai Mesin Pencari Default. Untuk cara melakukannya di browser kromium, klik<a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
     },
     "redirect": {
         "message": "Pengalihan"

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Impostare LibRedirect come motore di ricerca predefinito. Per i browser Chromium, premere <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>qui</a>."
+        "message": "Impostare LibRedirect come motore di ricerca predefinito. Per i browser Chromium, premere <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>qui</a>."
     },
     "redirect": {
         "message": "Reindirizza"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -137,7 +137,7 @@
         "message": "表示しない"
     },
     "searchHint": {
-        "message": "LibRedirect を標準の検索エンジンに設定します。chromium ブラウザーでのやり方は、<a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>こちらをクリック</a>。"
+        "message": "LibRedirect を標準の検索エンジンに設定します。chromium ブラウザーでのやり方は、<a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>こちらをクリック</a>。"
     },
     "redirect": {
         "message": "転送する"

--- a/src/_locales/jv/messages.json
+++ b/src/_locales/jv/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
+        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
     },
     "redirect": {
         "message": "Redirect"

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
+        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
     },
     "redirect": {
         "message": "Redirect"

--- a/src/_locales/nb_NO/messages.json
+++ b/src/_locales/nb_NO/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
+        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
     },
     "redirect": {
         "message": "Redirect"

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -137,7 +137,7 @@
         "message": "Zablokuj"
     },
     "searchHint": {
-        "message": "Ustaw LibRedirect jako domyślną wyszukiwarkę. Aby dowiedzieć się, jak to zrobić w przeglądarkach Chromium, kliknij <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>tutaj</a>."
+        "message": "Ustaw LibRedirect jako domyślną wyszukiwarkę. Aby dowiedzieć się, jak to zrobić w przeglądarkach Chromium, kliknij <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>tutaj</a>."
     },
     "redirect": {
         "message": "Przekieruj"

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
+        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
     },
     "redirect": {
         "message": "Redirect"

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Configure LibRedirect como Motor de Pesquisa Padrão. Para como fazer em navegadores Chromium, clique <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>aqui</a>."
+        "message": "Configure LibRedirect como Motor de Pesquisa Padrão. Para como fazer em navegadores Chromium, clique <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>aqui</a>."
     },
     "redirect": {
         "message": "Redirecionar"

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
+        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
     },
     "redirect": {
         "message": "Redirect"

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Установить LibRedirect в качестве поисковой системы по умолчанию. Подробности о том, как это сделать в браузерах на Chromium, доступны <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>здесь</a>."
+        "message": "Установить LibRedirect в качестве поисковой системы по умолчанию. Подробности о том, как это сделать в браузерах на Chromium, доступны <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>здесь</a>."
     },
     "redirect": {
         "message": "Перенаправить"

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -137,7 +137,7 @@
         "message": "Блокирајте"
     },
     "searchHint": {
-        "message": "Поставите ЛибРедирецт као стандардни тражионик. <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>Овде</a> погледајте како се то ради у Кромијум мрежном прегледнику."
+        "message": "Поставите ЛибРедирецт као стандардни тражионик. <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>Овде</a> погледајте како се то ради у Кромијум мрежном прегледнику."
     },
     "redirect": {
         "message": "Преусмерите"

--- a/src/_locales/ta/messages.json
+++ b/src/_locales/ta/messages.json
@@ -117,7 +117,7 @@
         "message": "தொகுதி"
     },
     "searchHint": {
-        "message": "இயல்புநிலை தேடுபொறியாக Lirbredirect ஐ அமைக்கவும். குரோமியம் உலாவிகளில் எவ்வாறு செய்வது என்பதற்கு, <a href = 'https: //libredirect.github.io/docs.html#search_engine_chromium' target = '_ வெற்று' rel = 'noopener norferrer'> இங்கே </a>."
+        "message": "இயல்புநிலை தேடுபொறியாக Lirbredirect ஐ அமைக்கவும். குரோமியம் உலாவிகளில் எவ்வாறு செய்வது என்பதற்கு, <a href = 'https: //libredirect.manerakai.com/docs.html#search_engine_chromium' target = '_ வெற்று' rel = 'noopener norferrer'> இங்கே </a>."
     },
     "redirect": {
         "message": "திருப்பி விடுங்கள்"

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "LibRedirect'i öntanımlı arama moturu olarak ayarlayın. Chromium tabanlı tarayıcılarda nasıl yapılacağını öğrenmek için <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>buraya</a> tıklayın."
+        "message": "LibRedirect'i öntanımlı arama moturu olarak ayarlayın. Chromium tabanlı tarayıcılarda nasıl yapılacağını öğrenmek için <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>buraya</a> tıklayın."
     },
     "redirect": {
         "message": "Yönlendir"

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Установити LibRedirect усталеним засобом пошуку. Як це зробити у браузерах на основі chromium, читайте <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>тут</a>."
+        "message": "Установити LibRedirect усталеним засобом пошуку. Як це зробити у браузерах на основі chromium, читайте <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>тут</a>."
     },
     "redirect": {
         "message": "Переспрямувати"

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -137,7 +137,7 @@
         "message": "Block"
     },
     "searchHint": {
-        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
+        "message": "Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click <a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>here</a>."
     },
     "redirect": {
         "message": "Redirect"

--- a/src/_locales/zh_Hans/messages.json
+++ b/src/_locales/zh_Hans/messages.json
@@ -137,7 +137,7 @@
         "message": "屏蔽"
     },
     "searchHint": {
-        "message": "请将 LibRedirect 设为默认搜索引擎。Chromium 浏览器的操作方法，点击<a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>此处</a>了解。"
+        "message": "请将 LibRedirect 设为默认搜索引擎。Chromium 浏览器的操作方法，点击<a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>此处</a>了解。"
     },
     "redirect": {
         "message": "重定向"

--- a/src/_locales/zh_Hant/messages.json
+++ b/src/_locales/zh_Hant/messages.json
@@ -137,7 +137,7 @@
         "message": "封鎖"
     },
     "searchHint": {
-        "message": "設定 LibRedirect 為預設搜尋引擎。如要了解如何在 Chromium 瀏覽器中執行操作，請點擊<a href='https://libredirect.github.io/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>此處</a>。"
+        "message": "設定 LibRedirect 為預設搜尋引擎。如要了解如何在 Chromium 瀏覽器中執行操作，請點擊<a href='https://libredirect.manerakai.com/docs.html#search_engine_chromium' target='_blank' rel='noopener noreferrer'>此處</a>。"
     },
     "redirect": {
         "message": "重新導向"

--- a/src/pages/options_src/Services/Instances.svelte
+++ b/src/pages/options_src/Services/Instances.svelte
@@ -222,7 +222,7 @@
                   <a href={instance} target="_blank" rel="noopener noreferrer">{instance}</a>
                   {#if blacklist.cloudflare.includes(instance)}
                     <a
-                      href="https://libredirect.github.io/docs.html#instances"
+                      href="https://libredirect.manerakai.com/docs.html#instances"
                       target="_blank"
                       rel="noopener noreferrer"
                       style="color:red;"

--- a/src/pages/options_src/Services/Services.svelte
+++ b/src/pages/options_src/Services/Services.svelte
@@ -202,7 +202,7 @@
           {@html browser.i18n.getMessage("searchHint") ||
             `Set LibRedirect as Default Search Engine. For how to do in chromium browsers, click
           <a
-            href="https://libredirect.github.io/docs.html#search_engine_chromium"
+            href="https://libredirect.manerakai.com/docs.html#search_engine_chromium"
             target="_blank"
             rel="noopener noreferrer"
             >here

--- a/src/pages/options_src/Sidebar.svelte
+++ b/src/pages/options_src/Sidebar.svelte
@@ -17,7 +17,7 @@
     <ServicesIcon class="margin margin_{document.body.dir}" />
     {browser.i18n.getMessage("services") || "Services"}
   </a>
-  <a href="https://libredirect.github.io" target="_blank" rel="noopener noreferrer">
+  <a href="https://libredirect.manerakai.com" target="_blank" rel="noopener noreferrer">
     <AboutIcon class="margin margin_{document.body.dir}" />
     {browser.i18n.getMessage("about") || "About"}
   </a>


### PR DESCRIPTION
`libredirect.github.io` domain is broken and `libredirect.manerakai.com` seems to be the new domain name now.

All links work with the new domain.